### PR TITLE
clean yum cache to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN cd /home \
     && wget -O install.sh http://download.bt.cn/install/install_6.0.sh \
     && echo y | bash install.sh \
     && python /set_default.py \
-    && echo '["linuxsys", "webssh"]' > /www/server/panel/config/index.json
+    && echo '["linuxsys", "webssh"]' > /www/server/panel/config/index.json \
+    && yum clean all
 
 WORKDIR /www/wwwroot
 CMD /entrypoint.sh


### PR DESCRIPTION
安装完成后清除yum缓存，减小docker镜像大小约132.2M，668.6MB -> 536.4MB